### PR TITLE
feat: add swiftformatter as pre-commit hook

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,5 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npx --no -- commitlint --edit 
+npx --no -- commitlint --edit
+git-format-staged --formatter "swiftformat stdin --stdinpath '{}'" "*.swift"

--- a/Pino-iOS/.swiftformat
+++ b/Pino-iOS/.swiftformat
@@ -1,0 +1,106 @@
+# SwiftFormat config compliant with Google Swift Guideline
+# https://google.github.io/swift/#control-flow-statements
+
+# Specify version used in a project
+
+--swiftversion 5.5
+
+# Rules explicitly required by the guideline
+
+--rules                           \
+blankLinesAroundMark,             \
+blankLineAfterImports,		  \
+blankLinesAtEndOfScope,           \
+blankLinesBetweenImports,	  \
+blankLinesAtStartOfScope,         \
+blankLinesBetweenScopes,          \
+braces,                           \
+consecutiveBlankLines,            \
+consecutiveSpaces,                \
+duplicateImports,                 \
+elseOnSameLine,                   \
+emptyBraces,                      \
+enumNamespaces,                   \
+extensionAccessControl,           \
+hoistPatternLet,                  \
+indent,                           \
+leadingDelimiters,                \
+linebreakAtEndOfFile,             \
+modifierOrder,			  \
+redundantInit,                    \
+numberFormatting,		  \
+redundantParens,                  \
+redundantPattern,                 \
+redundantType,                    \
+redundantVoidReturnType,          \
+semicolons,                       \
+sortedImports,                    \
+spaceAroundBraces,                \
+spaceAroundBrackets,              \
+spaceAroundComments,              \
+spaceAroundGenerics,              \
+spaceAroundOperators,             \
+spaceAroundParens,                \
+spaceInsideBraces,                \
+spaceInsideBrackets,              \
+spaceInsideComments,              \
+spaceInsideGenerics,              \
+spaceInsideParens,                \
+todos,                            \
+trailingClosures,                 \
+trailingCommas,                   \
+trailingSpace,                    \
+typeSugar,                        \
+void,                             \
+wrap,                             \
+wrapArguments,                    \
+wrapSingleLineComments,		  \
+wrapAttributes,                   \
+wrapEnumCases,			  \
+#
+#
+# Additional rules not mentioned in the guideline, but helping to keep the codebase clean 
+# Quoting the guideline: 
+# Common themes among the rules in this section are: 
+# avoid redundancy, avoid ambiguity, and prefer implicitness over explicitness
+# unless being explicit improves readability and/or reduces ambiguity.
+#
+#
+isEmpty,                          \
+redundantBackticks,               \
+redundantBreak,                   \
+redundantExtensionACL,            \
+redundantGet,                     \
+redundantLetError,                \
+redundantNilInit,                 \
+redundantObjc,                    \
+redundantReturn,                  \
+redundantSelf,                    \
+redundantOptionalBinding,	  \
+strongifiedSelf
+
+
+# Options for basic rules
+--extensionacl on-declarations
+--funcattributes prev-line
+--indent tab
+--maxwidth 120
+--typeattributes prev-line
+--varattributes prev-line
+--voidtype tuple
+--wraparguments before-first
+--wrapparameters before-first
+--wrapcollections before-first
+--wrapreturntype preserve
+--wrapconditions after-first 
+--redundanttype inferred
+
+# Option for additional rules
+
+--self init-only
+
+# Excluded folders
+
+--exclude Pods,**/UNTESTED_TODO,vendor,fastlane
+
+# https://github.com/NoemiRozpara/Google-SwiftFormat-Config


### PR DESCRIPTION
Added swift format to project.
### Notes on SwiftFormat

1. Make sure  to run `swiftformat .` before committing your changes
2. Incase you forgot to run the command, it will be run, but you'll need to submit a new commit for changes in formatting 